### PR TITLE
Added Nordic Energy Token

### DIFF
--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -198,5 +198,14 @@
     "decimals": 18,
     "chainId": 1,
     "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png"
+  },
+  {
+    "name": "Nordic Energy",
+    "address": "0x4D0A4C762BD7f742096DAAF5911dcf9C94b9ea95",
+    "symbol": "NET",
+    "decimals": 8,
+    "chainId": 1,
+    "logoURI": "https://i.imgur.com/wOmG3UV.png"
+     
   }
 ]

--- a/src/tokens/mainnet.json
+++ b/src/tokens/mainnet.json
@@ -200,7 +200,7 @@
     "logoURI": "https://assets.coingecko.com/coins/images/913/large/LRC.png"
   },
   {
-    "name": "Nordic Energy",
+    "name": "Nordic Energy Token",
     "address": "0x4D0A4C762BD7f742096DAAF5911dcf9C94b9ea95",
     "symbol": "NET",
     "decimals": 8,


### PR DESCRIPTION
"chainId": 1,
      "address": "0x4D0A4C762BD7f742096DAAF5911dcf9C94b9ea95",
      "symbol": "NET",
      "name": "Nordic Energy Token",
      "decimals": 8,
      "logoURI": "https://i.imgur.com/wOmG3UV.png",